### PR TITLE
Do less in charging state

### DIFF
--- a/src/board/drivers/frontend.rs
+++ b/src/board/drivers/frontend.rs
@@ -127,6 +127,13 @@ where
         self.touch.is_low().unwrap()
     }
 
+    pub async fn wait_for_touch(&mut self)
+    where
+        TOUCH: Wait,
+    {
+        _ = self.touch.wait_for_low().await;
+    }
+
     pub fn split(self) -> (S, DRDY, RESET, TOUCH) {
         (self.adc.into_inner(), self.drdy, self.reset, self.touch)
     }

--- a/src/board/initialized.rs
+++ b/src/board/initialized.rs
@@ -1,6 +1,5 @@
 use embassy_executor::SendSpawner;
 use embedded_hal::digital::InputPin;
-use embedded_hal_async::digital::Wait;
 use gui::screens::BatteryInfo;
 
 use crate::{
@@ -34,13 +33,6 @@ impl<VBUS: InputPin, CHG: InputPin> BatteryMonitor<VBUS, CHG> {
 
     pub fn is_charging(&self) -> bool {
         self.charger_status.is_low().unwrap()
-    }
-
-    pub async fn wait_for_unplugged(&mut self)
-    where
-        VBUS: Wait,
-    {
-        _ = self.vbus_detect.wait_for_low().await;
     }
 }
 

--- a/src/board/initialized.rs
+++ b/src/board/initialized.rs
@@ -1,5 +1,6 @@
 use embassy_executor::SendSpawner;
 use embedded_hal::digital::InputPin;
+use embedded_hal_async::digital::Wait;
 use gui::screens::BatteryInfo;
 
 use crate::{
@@ -33,6 +34,13 @@ impl<VBUS: InputPin, CHG: InputPin> BatteryMonitor<VBUS, CHG> {
 
     pub fn is_charging(&self) -> bool {
         self.charger_status.is_low().unwrap()
+    }
+
+    pub async fn wait_for_unplugged(&mut self)
+    where
+        VBUS: Wait,
+    {
+        _ = self.vbus_detect.wait_for_low().await;
     }
 }
 

--- a/src/states/charging.rs
+++ b/src/states/charging.rs
@@ -2,7 +2,6 @@ use crate::{
     board::{initialized::Board, BATTERY_MODEL},
     AppState,
 };
-use embassy_futures::select::select;
 use embassy_time::{Duration, Instant, Ticker};
 use embedded_graphics::Drawable;
 use gui::screens::charging::ChargingScreen;
@@ -16,58 +15,31 @@ pub async fn charging(board: &mut Board) -> AppState {
 
     // Count displayed frames since last wakeup
     let mut frames = 0;
-    let mut display_active = false;
 
-    while board.battery_monitor.is_plugged() {
+    while board.battery_monitor.is_plugged() && display_started.elapsed() <= DISPLAY_TIME {
         if board.frontend.is_touched() {
-            if !display_active {
-                frames = 0;
-            }
-
             display_started = Instant::now();
         }
 
-        let elapsed = display_started.elapsed();
-        if elapsed <= DISPLAY_TIME {
-            display_active = true;
-            let battery_data = board.battery_monitor.battery_data().await;
-            board
-                .display
-                .frame(|display| {
-                    ChargingScreen {
-                        battery_data,
-                        model: BATTERY_MODEL,
-                        is_charging: board.battery_monitor.is_charging(),
-                        frames,
-                        fps: FPS,
-                    }
-                    .draw(display)
-                })
-                .await
-                .unwrap();
+        let battery_data = board.battery_monitor.battery_data().await;
+        board
+            .display
+            .frame(|display| {
+                ChargingScreen {
+                    battery_data,
+                    model: BATTERY_MODEL,
+                    is_charging: board.battery_monitor.is_charging(),
+                    frames,
+                    fps: FPS,
+                }
+                .draw(display)
+            })
+            .await
+            .unwrap();
 
-            frames += 1;
-            ticker.next().await;
-        } else if display_active {
-            // Clear display
-            board.display.frame(|_display| Ok(())).await.unwrap();
-            display_active = false;
-
-            log::debug!("Sleeping");
-            select(
-                board.battery_monitor.wait_for_unplugged(),
-                board.frontend.wait_for_touch(),
-            )
-            .await;
-            log::debug!("Wakeup");
-            ticker = Ticker::every(Duration::from_hz(FPS as u64));
-            if !display_active {
-                frames = 0;
-            }
-
-            display_started = Instant::now();
-        }
+        frames += 1;
+        ticker.next().await;
     }
 
-    AppState::Shutdown
+    AppState::ShutdownCharging
 }


### PR DESCRIPTION
This PR shuts the board down during charging, if the display should be inactive.

## Old description

Ideally, we could just go sleeping (modulo battery monitoring, which could be paused as well, probably) until
- electrodes are touched
- or device gets unplugged

Unfortunately, the select makes the app freeze, so blocked on https://github.com/esp-rs/esp-hal/issues/561