### PR TITLE
Pass around the split socket and simplify impl

### DIFF
--- a/bad-server/Cargo.toml
+++ b/bad-server/Cargo.toml
@@ -23,3 +23,7 @@ simple_logger="4.1"
 default = []
 std = ["async-io", "smol"]
 embassy = ["embassy-net"]
+
+[[example]]
+name = "simple"
+required-features = ["std"]

--- a/bad-server/examples/simple.rs
+++ b/bad-server/examples/simple.rs
@@ -5,8 +5,8 @@
 use bad_server::{
     connector::{std_compat::StdTcpSocket, Connection},
     handler::RequestHandler,
-    request_context::RequestContext,
-    response::ResponseStatus,
+    request::Request,
+    response::{Response, ResponseStatus},
     BadServer, HandleError,
 };
 use log::LevelFilter;
@@ -23,10 +23,14 @@ fn main() {
 
 struct RootHandler;
 impl<C: Connection> RequestHandler<C> for RootHandler {
-    async fn handle(&self, request: RequestContext<'_, C>) -> Result<(), HandleError<C>> {
-        let request = request.send_status(ResponseStatus::Ok).await?;
-        let mut request = request.end_headers().await?;
-        request.write_string("Hello, world!").await?;
+    async fn handle(
+        &self,
+        _request: Request<'_, '_, C>,
+        response: Response<'_, C>,
+    ) -> Result<(), HandleError<C>> {
+        let response = response.send_status(ResponseStatus::Ok).await?;
+        let mut response = response.start_body().await?;
+        response.write_string("Hello, world!").await?;
         Ok(())
     }
 }

--- a/bad-server/src/handler.rs
+++ b/bad-server/src/handler.rs
@@ -2,18 +2,21 @@ use core::marker::PhantomData;
 
 use object_chain::{Chain, ChainElement, Link};
 
-use crate::{connector::Connection, method::Method, request_context::RequestContext, HandleError};
+use crate::{
+    connector::Connection, method::Method, request::Request, response::Response, HandleError,
+};
 
 pub trait Handler {
     type Connection: Connection;
 
     /// Returns `true` if this handler can handle the given request.
-    fn handles(&self, request: &RequestContext<'_, Self::Connection>) -> bool;
+    fn handles(&self, request: &Request<'_, '_, Self::Connection>) -> bool;
 
     /// Handles the given request.
     async fn handle(
         &self,
-        request: RequestContext<'_, Self::Connection>,
+        request: Request<'_, '_, Self::Connection>,
+        response: Response<'_, Self::Connection>,
     ) -> Result<(), HandleError<Self::Connection>>;
 }
 
@@ -21,17 +24,25 @@ pub struct NoHandler<C: Connection>(pub(crate) PhantomData<C>);
 impl<C: Connection> Handler for NoHandler<C> {
     type Connection = C;
 
-    fn handles(&self, _request: &RequestContext<'_, C>) -> bool {
+    fn handles(&self, _request: &Request<'_, '_, C>) -> bool {
         false
     }
 
-    async fn handle(&self, _request: RequestContext<'_, C>) -> Result<(), HandleError<C>> {
+    async fn handle(
+        &self,
+        _request: Request<'_, '_, C>,
+        _response: Response<'_, C>,
+    ) -> Result<(), HandleError<C>> {
         Ok(())
     }
 }
 
 pub trait RequestHandler<C: Connection> {
-    async fn handle(&self, request: RequestContext<'_, C>) -> Result<(), HandleError<C>>;
+    async fn handle(
+        &self,
+        request: Request<'_, '_, C>,
+        response: Response<'_, C>,
+    ) -> Result<(), HandleError<C>>;
 
     fn new<'a>(method: Method, path: &'a str, handler: Self) -> RequestWithMatcher<'a, C, Self>
     where
@@ -80,12 +91,16 @@ where
 {
     type Connection = C;
 
-    fn handles(&self, request: &RequestContext<'_, C>) -> bool {
-        self.method == request.method() && self.path == request.path()
+    fn handles(&self, request: &Request<'_, '_, C>) -> bool {
+        self.method == request.method && self.path == request.path
     }
 
-    async fn handle(&self, request: RequestContext<'_, C>) -> Result<(), HandleError<C>> {
-        self.handler.handle(request).await
+    async fn handle(
+        &self,
+        request: Request<'_, '_, C>,
+        response: Response<'_, C>,
+    ) -> Result<(), HandleError<C>> {
+        self.handler.handle(request, response).await
     }
 }
 
@@ -95,12 +110,17 @@ where
     C: Connection,
 {
     type Connection = C;
-    fn handles(&self, request: &RequestContext<'_, C>) -> bool {
+
+    fn handles(&self, request: &Request<'_, '_, C>) -> bool {
         self.object.handles(request)
     }
 
-    async fn handle(&self, request: RequestContext<'_, C>) -> Result<(), HandleError<C>> {
-        self.object.handle(request).await
+    async fn handle(
+        &self,
+        request: Request<'_, '_, C>,
+        response: Response<'_, C>,
+    ) -> Result<(), HandleError<C>> {
+        self.object.handle(request, response).await
     }
 }
 
@@ -112,15 +132,19 @@ where
 {
     type Connection = C;
 
-    fn handles(&self, request: &RequestContext<'_, C>) -> bool {
+    fn handles(&self, request: &Request<'_, '_, C>) -> bool {
         self.object.handles(request) || self.parent.handles(request)
     }
 
-    async fn handle(&self, request: RequestContext<'_, C>) -> Result<(), HandleError<C>> {
+    async fn handle(
+        &self,
+        request: Request<'_, '_, C>,
+        response: Response<'_, C>,
+    ) -> Result<(), HandleError<C>> {
         if self.object.handles(&request) {
-            self.object.handle(request).await
+            self.object.handle(request, response).await
         } else {
-            self.parent.handle(request).await
+            self.parent.handle(request, response).await
         }
     }
 }


### PR DESCRIPTION
This is an idea that simplifies code greatly but does not compile with 1.69.0.1